### PR TITLE
🚧  💩  Add new endpoint to get current incidence details for province from RKI API 🚧

### DIFF
--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
@@ -1,6 +1,7 @@
 package de.neuefische.teddyscoronadiaries.controller;
 
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetailsProvince;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiAttributes;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
@@ -31,6 +32,11 @@ public class CovidController {
     @GetMapping("{quarantineDay}")
     public IncidenceDetails getCases(@PathVariable int quarantineDay){
         return covidService.getSevenDayIncidenceForQuarantineDay(quarantineDay);
+    }
+
+    @GetMapping("/province/{province}")
+    public IncidenceDetailsProvince getIncidenceDetailsForProvince(@PathVariable String province){
+        return covidService.getSevenDayIncidenceValueForProvince(province);
     }
 
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
@@ -1,27 +1,31 @@
 package de.neuefische.teddyscoronadiaries.controller;
 
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiAttributes;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
 import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
 import de.neuefische.teddyscoronadiaries.service.CovidService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
 
 @RestController
 @RequestMapping("api/covid")
 public class CovidController {
 
     private final CovidService covidService;
-    private final RkiApiService rkiApiService;
 
     @Autowired
     public CovidController(CovidService covidService, RkiApiService rkiApiService) {
         this.covidService = covidService;
-        this.rkiApiService = rkiApiService;
     }
 
     @GetMapping("{quarantineDay}")
@@ -29,8 +33,4 @@ public class CovidController {
         return covidService.getSevenDayIncidenceForQuarantineDay(quarantineDay);
     }
 
-    @GetMapping("province/{province}")
-    public RkiIncidenceWrapper getIncidenceValue(@PathVariable String province){
-        return rkiApiService.getIncidenceValueForProvince(province);
-    }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/CovidController.java
@@ -1,6 +1,9 @@
 package de.neuefische.teddyscoronadiaries.controller;
 
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
+import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
 import de.neuefische.teddyscoronadiaries.service.CovidService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,21 +11,26 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("api/covid")
 public class CovidController {
 
     private final CovidService covidService;
+    private final RkiApiService rkiApiService;
 
     @Autowired
-    public CovidController(CovidService covidService) {
+    public CovidController(CovidService covidService, RkiApiService rkiApiService) {
         this.covidService = covidService;
+        this.rkiApiService = rkiApiService;
     }
 
     @GetMapping("{quarantineDay}")
     public IncidenceDetails getCases(@PathVariable int quarantineDay){
         return covidService.getSevenDayIncidenceForQuarantineDay(quarantineDay);
+    }
+
+    @GetMapping("province/{province}")
+    public RkiIncidenceWrapper getIncidenceValue(@PathVariable String province){
+        return rkiApiService.getIncidenceValueForProvince(province);
     }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/covid/IncidenceDetailsProvince.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/covid/IncidenceDetailsProvince.java
@@ -1,0 +1,16 @@
+package de.neuefische.teddyscoronadiaries.model.covid;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class IncidenceDetailsProvince {
+
+    private String provinceName;
+    private int totalCases;
+    private int incidenceValue;
+    private IncidenceLevel incidenceLevel;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiAttributes.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiAttributes.java
@@ -1,0 +1,17 @@
+package de.neuefische.teddyscoronadiaries.rkiapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RkiAttributes {
+
+    @JsonProperty("attributes")
+    private List<RkiIncidenceValue> attributes;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiAttributes.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiAttributes.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @AllArgsConstructor
@@ -13,5 +14,5 @@ import java.util.List;
 public class RkiAttributes {
 
     @JsonProperty("attributes")
-    private List<RkiIncidenceValue> attributes;
+    private RkiIncidenceValue attributes;
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceValue.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceValue.java
@@ -14,5 +14,5 @@ public class RkiIncidenceValue {
     @JsonProperty("Fallzahl")
     private int totalCases;
     @JsonProperty("cases7_bl_per_100k")
-    private float sevenDayIncidenceValue;
+    private double sevenDayIncidenceValue;
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceValue.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceValue.java
@@ -1,0 +1,18 @@
+package de.neuefische.teddyscoronadiaries.rkiapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RkiIncidenceValue {
+    @JsonProperty("LAN_ew_GEN")
+    private String province;
+    @JsonProperty("Fallzahl")
+    private int totalCases;
+    @JsonProperty("cases7_bl_per_100k")
+    private float sevenDayIncidenceValue;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceWrapper.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/model/RkiIncidenceWrapper.java
@@ -1,0 +1,17 @@
+package de.neuefische.teddyscoronadiaries.rkiapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RkiIncidenceWrapper {
+
+    @JsonProperty("features")
+    private List<RkiAttributes> features;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
@@ -1,0 +1,33 @@
+package de.neuefische.teddyscoronadiaries.rkiapi.service;
+
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+@Repository
+public class RkiApiService {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?";
+
+    @Autowired
+    public RkiApiService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public RkiIncidenceWrapper getIncidenceValueForProvince(String province) {
+
+        String url = baseUrl + "where=LAN_ew_GEN%20%3D%20'"
+                + province.toUpperCase()
+                + "'&outFields=LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false";
+
+        String testUrl = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20%27HAMBURG%27&outFields=LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false";
+
+        ResponseEntity<RkiIncidenceWrapper> response = restTemplate.getForEntity(testUrl, RkiIncidenceWrapper.class);
+
+        return response.getBody();
+    }
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
@@ -3,31 +3,54 @@ package de.neuefische.teddyscoronadiaries.rkiapi.service;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
 
 @Repository
 public class RkiApiService {
 
     private final RestTemplate restTemplate;
-    private final String baseUrl = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?";
+    private final String baseUrl = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query";
 
     @Autowired
     public RkiApiService(RestTemplate restTemplate) {
         this.restTemplate = restTemplate;
     }
 
-    public RkiIncidenceWrapper getIncidenceValueForProvince(String province) {
+    public Optional<RkiIncidenceValue> getIncidenceValueForProvince(String province) {
 
-        String url = baseUrl + "where=LAN_ew_GEN%20%3D%20'"
-                + province.toUpperCase()
-                + "'&outFields=LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false";
+        MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
 
-        String testUrl = "https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20%27HAMBURG%27&outFields=LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false";
+        converter.setSupportedMediaTypes(Arrays.asList(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON));
+        restTemplate.getMessageConverters().add(0, converter);
 
-        ResponseEntity<RkiIncidenceWrapper> response = restTemplate.getForEntity(testUrl, RkiIncidenceWrapper.class);
+        String provinceParameter = "LAN_ew_GEN%20%3D%20'" + province.toUpperCase() + "'";
 
-        return response.getBody();
+        try {
+
+            StringBuilder builder = new StringBuilder(baseUrl);
+            builder.append("?where=");
+            builder.append(provinceParameter);
+            builder.append("&outFields=");
+            builder.append(URLEncoder.encode("LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt", StandardCharsets.UTF_8.toString()));
+            builder.append("&outSR=4326&f=json&returnGeometry=false");
+
+            URI uri = URI.create(builder.toString());
+
+            ResponseEntity<RkiIncidenceWrapper> response = restTemplate.getForEntity(uri, RkiIncidenceWrapper.class);
+
+            return Optional.of(response.getBody().getFeatures().get(0).getAttributes());
+        } catch(Exception e) {
+            return Optional.empty();
+        }
     }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiService.java
@@ -38,18 +38,18 @@ public class RkiApiService {
         try {
 
             StringBuilder builder = new StringBuilder(baseUrl);
-            builder.append("?where=");
-            builder.append(provinceParameter);
-            builder.append("&outFields=");
-            builder.append(URLEncoder.encode("LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt", StandardCharsets.UTF_8.toString()));
-            builder.append("&outSR=4326&f=json&returnGeometry=false");
+            builder.append("?where=")
+                    .append(provinceParameter)
+                    .append("&outFields=")
+                    .append(URLEncoder.encode("LAN_ew_GEN,LAN_ew_BEZ,Fallzahl,Aktualisierung,faelle_100000_EW,cases7_bl_per_100k,cases7_bl,cases7_bl_per_100k_txt", StandardCharsets.UTF_8.toString()))
+                    .append("&outSR=4326&f=json&returnGeometry=false");
 
             URI uri = URI.create(builder.toString());
 
             ResponseEntity<RkiIncidenceWrapper> response = restTemplate.getForEntity(uri, RkiIncidenceWrapper.class);
 
             return Optional.of(response.getBody().getFeatures().get(0).getAttributes());
-        } catch(Exception e) {
+        } catch (Exception e) {
             return Optional.empty();
         }
     }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/CovidService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/CovidService.java
@@ -4,6 +4,8 @@ import de.neuefische.teddyscoronadiaries.covid19api.model.ConfirmedCase;
 import de.neuefische.teddyscoronadiaries.covid19api.service.Covid19ApiService;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceLevel;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -19,13 +21,15 @@ import java.util.Optional;
 public class CovidService {
 
     private final Covid19ApiService covid19ApiService;
+    private final RkiApiService rkiApiService;
     //Start day March 15th 2020
     private final Instant quarantineStart = Instant.ofEpochSecond(1584230400L);
     private static final int INHABITANTS_GERMANY = 83100000;
 
     @Autowired
-    public CovidService(Covid19ApiService covid19ApiService) {
+    public CovidService(Covid19ApiService covid19ApiService, RkiApiService rkiApiService) {
         this.covid19ApiService = covid19ApiService;
+        this.rkiApiService = rkiApiService;
     }
 
     public IncidenceDetails getSevenDayIncidenceForQuarantineDay(int quarantineDay){
@@ -36,6 +40,18 @@ public class CovidService {
                 startAndEndValue.get("endValue"));
 
         return new IncidenceDetails(incidenceValue, IncidenceLevel.determineIncidenceLevel(incidenceValue));
+    }
+
+    public IncidenceDetails getSevenDayIncidenceValueForProvince(String province) {
+
+        Optional<RkiIncidenceValue> rkiIncidenceValue = rkiApiService.getIncidenceValueForProvince(province);
+
+        if(rkiIncidenceValue.isEmpty()){ throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Incidence value not available");}
+
+        int incidenceValue = (int)Math.round(rkiIncidenceValue.get().getSevenDayIncidenceValue());
+
+        return new IncidenceDetails(incidenceValue, IncidenceLevel.determineIncidenceLevel(incidenceValue));
+
     }
 
     public HashMap<String, Integer> getStartAndEndValue(int quarantineDay) {

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/CovidService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/CovidService.java
@@ -3,6 +3,7 @@ package de.neuefische.teddyscoronadiaries.service;
 import de.neuefische.teddyscoronadiaries.covid19api.model.ConfirmedCase;
 import de.neuefische.teddyscoronadiaries.covid19api.service.Covid19ApiService;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetailsProvince;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceLevel;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
 import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
@@ -42,7 +43,7 @@ public class CovidService {
         return new IncidenceDetails(incidenceValue, IncidenceLevel.determineIncidenceLevel(incidenceValue));
     }
 
-    public IncidenceDetails getSevenDayIncidenceValueForProvince(String province) {
+    public IncidenceDetailsProvince getSevenDayIncidenceValueForProvince(String province) {
 
         Optional<RkiIncidenceValue> rkiIncidenceValue = rkiApiService.getIncidenceValueForProvince(province);
 
@@ -50,7 +51,9 @@ public class CovidService {
 
         int incidenceValue = (int)Math.round(rkiIncidenceValue.get().getSevenDayIncidenceValue());
 
-        return new IncidenceDetails(incidenceValue, IncidenceLevel.determineIncidenceLevel(incidenceValue));
+        return new IncidenceDetailsProvince(rkiIncidenceValue.get().getProvince()
+                , rkiIncidenceValue.get().getTotalCases()
+                ,incidenceValue, IncidenceLevel.determineIncidenceLevel(incidenceValue));
 
     }
 

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/CovidControllerTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/CovidControllerTest.java
@@ -2,7 +2,11 @@ package de.neuefische.teddyscoronadiaries.controller;
 
 import de.neuefische.teddyscoronadiaries.covid19api.model.ConfirmedCase;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetailsProvince;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceLevel;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiAttributes;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +16,12 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -61,6 +70,45 @@ class CovidControllerTest {
         // Then
         assertThat(response.getStatusCode(), is(HttpStatus.OK));
         assertThat(response.getBody(), is(new IncidenceDetails(72, IncidenceLevel.ORANGE)));
+    }
+
+    @Test
+    @DisplayName("Get seven day incidence value for province should return incidence details for province")
+    public void getSevenDayIncidenceValueForProvinceShouldReturnDetails(){
+        //Given
+        String province = "Hamburg";
+        URI url = URI.create("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20'HAMBURG'&outFields=LAN_ew_GEN%2CLAN_ew_BEZ%2CFallzahl%2CAktualisierung%2Cfaelle_100000_EW%2Ccases7_bl_per_100k%2Ccases7_bl%2Ccases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false");
+        RkiIncidenceWrapper rkiIncidenceWrapper = new RkiIncidenceWrapper(List.of(
+                new RkiAttributes(
+                        new RkiIncidenceValue("Hamburg", 50000, 103.7)
+                )
+        ));
+
+        when(restTemplate.getForEntity(url, RkiIncidenceWrapper.class)).thenReturn(ResponseEntity.ok(rkiIncidenceWrapper));
+
+        // When
+        ResponseEntity<IncidenceDetailsProvince> response = testRestTemplate.getForEntity(getUrl() + "/province/" + province, IncidenceDetailsProvince.class);
+
+        // Then
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(new IncidenceDetailsProvince("Hamburg", 50000, 104, IncidenceLevel.RED)));
+    }
+
+    @Test
+    @DisplayName("get seven day incidence value for province should return error when API not available")
+    public void getSevenDayIncidenceValueForProvinceShouldThrowError() {
+        // Given
+        String province = "Hamburg";
+        URI url = URI.create("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20'HAMBURG'&outFields=LAN_ew_GEN%2CLAN_ew_BEZ%2CFallzahl%2CAktualisierung%2Cfaelle_100000_EW%2Ccases7_bl_per_100k%2Ccases7_bl%2Ccases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false");
+
+        when(restTemplate.getForEntity(url, RkiIncidenceWrapper.class)).thenThrow(new RestClientException("Not available"));
+
+        // When
+        ResponseEntity<Void> response = testRestTemplate.getForEntity(getUrl() + "/province/" + province, Void.class);
+
+        // Then
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+
     }
 
 }

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiServiceTest.java
@@ -29,7 +29,6 @@ class RkiApiServiceTest {
     public void getIncidenceForProvinceShouldReturnIncidenceValue(){
         // Given
         URI url = URI.create("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20'HAMBURG'&outFields=LAN_ew_GEN%2CLAN_ew_BEZ%2CFallzahl%2CAktualisierung%2Cfaelle_100000_EW%2Ccases7_bl_per_100k%2Ccases7_bl%2Ccases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false");
-
         RkiIncidenceWrapper rkiIncidenceWrapper = new RkiIncidenceWrapper(List.of(
                 new RkiAttributes(
                         new RkiIncidenceValue("Hamburg", 50000, 103.7)

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/rkiapi/service/RkiApiServiceTest.java
@@ -1,0 +1,64 @@
+package de.neuefische.teddyscoronadiaries.rkiapi.service;
+
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiAttributes;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceWrapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RkiApiServiceTest {
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private final RkiApiService rkiApiService = new RkiApiService(restTemplate);
+
+    @Test
+    @DisplayName("Get incidence Value for province should return RKI incidence value object")
+    public void getIncidenceForProvinceShouldReturnIncidenceValue(){
+        // Given
+        URI url = URI.create("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20'HAMBURG'&outFields=LAN_ew_GEN%2CLAN_ew_BEZ%2CFallzahl%2CAktualisierung%2Cfaelle_100000_EW%2Ccases7_bl_per_100k%2Ccases7_bl%2Ccases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false");
+
+        RkiIncidenceWrapper rkiIncidenceWrapper = new RkiIncidenceWrapper(List.of(
+                new RkiAttributes(
+                        new RkiIncidenceValue("Hamburg", 50000, 103.7)
+                )
+        ));
+
+        when(restTemplate.getForEntity(url, RkiIncidenceWrapper.class)).thenReturn(ResponseEntity.ok(rkiIncidenceWrapper));
+
+        // When
+        Optional<RkiIncidenceValue> result = rkiApiService.getIncidenceValueForProvince("Hamburg");
+
+        // Then
+        assertThat(result.get(), is(new RkiIncidenceValue("Hamburg", 50000, 103.7)));
+
+    }
+
+    @Test
+    @DisplayName("Get incidence returns empty optional when request cannot be processed")
+    public void getIncidenceValueForProvinceReturnsEmptyOptional(){
+        // Given
+        URI url = URI.create("https://services7.arcgis.com/mOBPykOjAyBO2ZKk/arcgis/rest/services/Coronaf%C3%A4lle_in_den_Bundesl%C3%A4ndern/FeatureServer/0/query?where=LAN_ew_GEN%20%3D%20'HAMBURG'&outFields=LAN_ew_GEN%2CLAN_ew_BEZ%2CFallzahl%2CAktualisierung%2Cfaelle_100000_EW%2Ccases7_bl_per_100k%2Ccases7_bl%2Ccases7_bl_per_100k_txt&outSR=4326&f=json&returnGeometry=false");
+
+        when(restTemplate.getForEntity(url, RkiIncidenceWrapper.class)).thenThrow(new RestClientException("Not found"));
+
+        // When
+        Optional<RkiIncidenceValue> result = rkiApiService.getIncidenceValueForProvince("Hamburg");
+
+        // Then
+        assertTrue(result.isEmpty());
+
+    }
+}

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/CovidServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/CovidServiceTest.java
@@ -4,16 +4,18 @@ import de.neuefische.teddyscoronadiaries.covid19api.model.ConfirmedCase;
 import de.neuefische.teddyscoronadiaries.covid19api.service.Covid19ApiService;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceLevel;
+import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
+import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,7 +27,8 @@ import static org.mockito.Mockito.when;
 class CovidServiceTest {
 
     private final Covid19ApiService covid19ApiService = mock(Covid19ApiService.class);
-    private final CovidService covidService = new CovidService(covid19ApiService);
+    private final RkiApiService rkiApiService = mock(RkiApiService.class);
+    private final CovidService covidService = new CovidService(covid19ApiService, rkiApiService);
     private static final int quarantineDay = 42;
 
     @Test
@@ -157,6 +160,34 @@ class CovidServiceTest {
                 Arguments.of(230000, 500000, 325),
                 Arguments.of(210000, 340000, 156)
         );
+    }
+
+    @Test
+    @DisplayName("Get seven day incidence value for province should return incidence details")
+    public void getSevenIncidenceValueShouldReturnIncidenceValue(){
+        // Given
+        String province = "Hamburg";
+        when(rkiApiService.getIncidenceValueForProvince("Hamburg"))
+                .thenReturn(Optional.of(new RkiIncidenceValue("Hamburg", 50000, 103.7)));
+
+        // When
+        IncidenceDetails result = covidService.getSevenDayIncidenceValueForProvince(province);
+
+        // Then
+        assertThat(result, is(new IncidenceDetails(104, IncidenceLevel.RED)));
+    }
+
+    @Test
+    @DisplayName("Get seven day incidence for province should throw error when endpoint unavailable")
+    public void getSevenDayIncidenceForProvinceShouldThrowException(){
+        // Given
+        String province = "Hamburg";
+        when(rkiApiService.getIncidenceValueForProvince(province)).thenReturn(Optional.empty());
+
+        // Then
+        assertThrows(ResponseStatusException.class, () -> {
+            covidService.getSevenDayIncidenceValueForProvince(province);
+        });
     }
 
 }

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/CovidServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/CovidServiceTest.java
@@ -3,6 +3,7 @@ package de.neuefische.teddyscoronadiaries.service;
 import de.neuefische.teddyscoronadiaries.covid19api.model.ConfirmedCase;
 import de.neuefische.teddyscoronadiaries.covid19api.service.Covid19ApiService;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetails;
+import de.neuefische.teddyscoronadiaries.model.covid.IncidenceDetailsProvince;
 import de.neuefische.teddyscoronadiaries.model.covid.IncidenceLevel;
 import de.neuefische.teddyscoronadiaries.rkiapi.model.RkiIncidenceValue;
 import de.neuefische.teddyscoronadiaries.rkiapi.service.RkiApiService;
@@ -171,10 +172,10 @@ class CovidServiceTest {
                 .thenReturn(Optional.of(new RkiIncidenceValue("Hamburg", 50000, 103.7)));
 
         // When
-        IncidenceDetails result = covidService.getSevenDayIncidenceValueForProvince(province);
+        IncidenceDetailsProvince result = covidService.getSevenDayIncidenceValueForProvince(province);
 
         // Then
-        assertThat(result, is(new IncidenceDetails(104, IncidenceLevel.RED)));
+        assertThat(result, is(new IncidenceDetailsProvince("Hamburg", 50000, 104, IncidenceLevel.RED)));
     }
 
     @Test


### PR DESCRIPTION
- add new RKI API service with some hacks (URI encoding, additional accepted response type)
- add new model class for incidence details for province
- add service method to translate RKI information into incidence details
- add get mapping to Covid controller to get incidence details for province
- add tests for new methods 