### PR TITLE
☔️  Add metaweather API to backend ⛈ 🦑

### DIFF
--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/WeatherController.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/WeatherController.java
@@ -1,0 +1,4 @@
+package de.neuefische.teddyscoronadiaries.controller;
+
+public class WeatherController {
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/WeatherController.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/controller/WeatherController.java
@@ -1,4 +1,26 @@
 package de.neuefische.teddyscoronadiaries.controller;
 
+import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherData;
+import de.neuefische.teddyscoronadiaries.service.WeatherService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/weather")
 public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @Autowired
+    public WeatherController(WeatherService weatherService) {
+        this.weatherService = weatherService;
+    }
+
+    @GetMapping("{province}")
+    public ProvinceCapitalWeatherData getProvinceCapitalWeatherData(@PathVariable String province) {
+        return weatherService.getProvinceCapitalWeatherData(province);
+    }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/db/ProvinceMongoDb.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/db/ProvinceMongoDb.java
@@ -1,0 +1,11 @@
+package de.neuefische.teddyscoronadiaries.db;
+
+import de.neuefische.teddyscoronadiaries.model.province.ProvinceData;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import java.util.List;
+
+public interface ProvinceMongoDb extends PagingAndSortingRepository<ProvinceData, String> {
+
+    List<ProvinceData> findAll();
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/model/WeatherData.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/model/WeatherData.java
@@ -1,0 +1,32 @@
+package de.neuefische.teddyscoronadiaries.metaweatherapi.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WeatherData {
+
+    private String id;
+    @JsonProperty("weather_state_name")
+    private String weatherStateName;
+    @JsonProperty("weather_state_abbr")
+    private String weatherStateAbbreviation;
+    @JsonProperty("applicable_date")
+    private String applicableDate;
+    @JsonProperty("min_temp")
+    private Double minTemperature;
+    @JsonProperty("max_temp")
+    private Double maxTemperature;
+    @JsonProperty("the_temp")
+    private Double currentTemperature;
+    @JsonProperty("wind_speed")
+    private Double windSpeed;
+    @JsonProperty("humidity")
+    private int humidity;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/model/WeatherDataWrapper.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/model/WeatherDataWrapper.java
@@ -1,0 +1,18 @@
+package de.neuefische.teddyscoronadiaries.metaweatherapi.model;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class WeatherDataWrapper {
+
+    @JsonProperty("consolidated_weather")
+    private List<WeatherData> consolidatedWeather;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/service/MetaWeatherApiService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/metaweatherapi/service/MetaWeatherApiService.java
@@ -1,0 +1,34 @@
+package de.neuefische.teddyscoronadiaries.metaweatherapi.service;
+
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherData;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherDataWrapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Service
+public class MetaWeatherApiService {
+
+    private final RestTemplate restTemplate;
+    private static final String baseUrl = "https://www.metaweather.com";
+
+    @Autowired
+    public MetaWeatherApiService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+
+    public List<WeatherData> getWeatherData(String woeid) {
+        try {
+            ResponseEntity<WeatherDataWrapper> response = restTemplate.getForEntity(baseUrl + "/api/location/" + woeid, WeatherDataWrapper.class);
+            return response.getBody().getConsolidatedWeather();
+        } catch(Exception e) {
+            return List.of();
+        }
+    }
+
+
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/province/ProvinceData.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/province/ProvinceData.java
@@ -1,0 +1,19 @@
+package de.neuefische.teddyscoronadiaries.model.province;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "provinces")
+public class ProvinceData {
+
+    @Id
+    private String name;
+    private String capital;
+    private String capitalWoeid;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/ProvinceCapitalWeatherData.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/ProvinceCapitalWeatherData.java
@@ -14,4 +14,5 @@ public class ProvinceCapitalWeatherData {
     private int minTemperature;
     private int maxTemperature;
     private int currentTemperature;
+    private String weatherIconUrl;
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/ProvinceCapitalWeatherData.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/ProvinceCapitalWeatherData.java
@@ -1,0 +1,17 @@
+package de.neuefische.teddyscoronadiaries.model.weather;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProvinceCapitalWeatherData {
+
+    private String capital;
+    private String weatherState;
+    private int minTemperature;
+    private int maxTemperature;
+    private int currentTemperature;
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
@@ -16,9 +16,9 @@ public enum WeatherCategories {
 
     private WeatherCategories(String name) {this.name = name;}
 
-    public String getName(WeatherCategories category) {
+    public static String getWeatherCategory(String category) {
         for(WeatherCategories weatherCategory : values()) {
-            if(category.equals(weatherCategory)) {return weatherCategory.name;}
+            if(category.equals(weatherCategory.toString())) {return weatherCategory.name;}
         }
         return null;
     }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
@@ -1,0 +1,25 @@
+package de.neuefische.teddyscoronadiaries.model.weather;
+
+public enum WeatherCategories {
+    SN("Schnee"),
+    SL("Schneeregen"),
+    H("Hagel"),
+    T("Gewitter"),
+    HR("Starkregen"),
+    LR("Leichter Regen"),
+    S("Regen"),
+    HC("Bewölkt"),
+    LC("Leicht bewölkt"),
+    C("Sonnig");
+
+    public final String name;
+
+    private WeatherCategories(String name) {this.name = name;}
+
+    public String getName(WeatherCategories category) {
+        for(WeatherCategories weatherCategory : values()) {
+            if(category.equals(weatherCategory)) {return weatherCategory.name;}
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategories.java
@@ -1,5 +1,7 @@
 package de.neuefische.teddyscoronadiaries.model.weather;
 
+import java.util.Optional;
+
 public enum WeatherCategories {
     SN("Schnee"),
     SL("Schneeregen"),
@@ -16,10 +18,10 @@ public enum WeatherCategories {
 
     private WeatherCategories(String name) {this.name = name;}
 
-    public static String getWeatherCategory(String category) {
+    public static Optional<String> getWeatherCategory(String category) {
         for(WeatherCategories weatherCategory : values()) {
-            if(category.equals(weatherCategory.toString())) {return weatherCategory.name;}
+            if(category.equals(weatherCategory.toString())) {return Optional.of(weatherCategory.name);}
         }
-        return null;
+        return Optional.empty();
     }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
@@ -37,7 +37,6 @@ public class WeatherService {
         }
 
         String capitalWoeid = provinceData.get().getCapitalWoeid();
-
         Optional<WeatherData> weatherDataForProvinceCapital = getWeatherDataForProvinceCapital(capitalWoeid);
 
         if(weatherDataForProvinceCapital.isEmpty()) {throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Weather API not available");}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
@@ -1,0 +1,24 @@
+package de.neuefische.teddyscoronadiaries.service;
+
+import de.neuefische.teddyscoronadiaries.db.ProvinceMongoDb;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.service.MetaWeatherApiService;
+import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class WeatherService {
+
+    private final MetaWeatherApiService metaWeatherApiService;
+    private final ProvinceMongoDb provinceMongoDb;
+
+    @Autowired
+    public WeatherService(MetaWeatherApiService metaWeatherApiService, ProvinceMongoDb provinceMongoDb) {
+        this.metaWeatherApiService = metaWeatherApiService;
+        this.provinceMongoDb = provinceMongoDb;
+    }
+
+    public ProvinceCapitalWeatherData getProvinceCapitalWeatherData(String province) {
+        return null;
+    }
+}

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
@@ -42,7 +42,7 @@ public class WeatherService {
 
         if(weatherDataForProvinceCapital.isEmpty()) {throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Weather API not available");}
 
-        return getProvinceCapitalWeatherData(provinceData.get().getCapital(), weatherDataForProvinceCapital.get());
+        return getProvinceCapitalWeatherDataFromWeatherData(provinceData.get().getCapital(), weatherDataForProvinceCapital.get());
     }
 
     public Optional<WeatherData> getWeatherDataForProvinceCapital(String capitalWoeid) {
@@ -53,13 +53,14 @@ public class WeatherService {
         return weatherData.stream().filter(dataSet -> dataSet.getApplicableDate().equals(currentDay)).findAny();
     }
 
-    public ProvinceCapitalWeatherData getProvinceCapitalWeatherData(String capital, WeatherData data) {
+    public ProvinceCapitalWeatherData getProvinceCapitalWeatherDataFromWeatherData(String capital, WeatherData data) {
         return new ProvinceCapitalWeatherData(
                 capital,
                 WeatherCategories.getWeatherCategory(data.getWeatherStateAbbreviation().toUpperCase()),
                 (int)Math.round(data.getMinTemperature()),
                 (int)Math.round(data.getMaxTemperature()),
-                (int)Math.round(data.getCurrentTemperature())
+                (int)Math.round(data.getCurrentTemperature()),
+                "https://www.metaweather.com/static/img/weather/" + data.getWeatherStateAbbreviation() + ".svg"
         );
     }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 @Service
@@ -53,9 +54,14 @@ public class WeatherService {
     }
 
     public ProvinceCapitalWeatherData getProvinceCapitalWeatherDataFromWeatherData(String capital, WeatherData data) {
+
+        if(WeatherCategories.getWeatherCategory(data.getWeatherStateAbbreviation().toUpperCase()).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown weather category");
+        }
+
         return new ProvinceCapitalWeatherData(
                 capital,
-                WeatherCategories.getWeatherCategory(data.getWeatherStateAbbreviation().toUpperCase()),
+                WeatherCategories.getWeatherCategory(data.getWeatherStateAbbreviation().toUpperCase()).get(),
                 (int)Math.round(data.getMinTemperature()),
                 (int)Math.round(data.getMaxTemperature()),
                 (int)Math.round(data.getCurrentTemperature()),

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/service/WeatherService.java
@@ -1,24 +1,65 @@
 package de.neuefische.teddyscoronadiaries.service;
 
 import de.neuefische.teddyscoronadiaries.db.ProvinceMongoDb;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherData;
 import de.neuefische.teddyscoronadiaries.metaweatherapi.service.MetaWeatherApiService;
+import de.neuefische.teddyscoronadiaries.model.province.ProvinceData;
 import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherData;
+import de.neuefische.teddyscoronadiaries.model.weather.WeatherCategories;
+import de.neuefische.teddyscoronadiaries.utils.CurrentDateUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 public class WeatherService {
 
     private final MetaWeatherApiService metaWeatherApiService;
     private final ProvinceMongoDb provinceMongoDb;
+    private final CurrentDateUtils currentDateUtils;
 
     @Autowired
-    public WeatherService(MetaWeatherApiService metaWeatherApiService, ProvinceMongoDb provinceMongoDb) {
+    public WeatherService(MetaWeatherApiService metaWeatherApiService, ProvinceMongoDb provinceMongoDb, CurrentDateUtils currentDateUtils) {
         this.metaWeatherApiService = metaWeatherApiService;
         this.provinceMongoDb = provinceMongoDb;
+        this.currentDateUtils = currentDateUtils;
     }
 
     public ProvinceCapitalWeatherData getProvinceCapitalWeatherData(String province) {
-        return null;
+        Optional<ProvinceData> provinceData = provinceMongoDb.findById(province);
+
+        if (provinceData.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Province not known");
+        }
+
+        String capitalWoeid = provinceData.get().getCapitalWoeid();
+
+        Optional<WeatherData> weatherDataForProvinceCapital = getWeatherDataForProvinceCapital(capitalWoeid);
+
+        if(weatherDataForProvinceCapital.isEmpty()) {throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Weather API not available");}
+
+        return getProvinceCapitalWeatherData(provinceData.get().getCapital(), weatherDataForProvinceCapital.get());
+    }
+
+    public Optional<WeatherData> getWeatherDataForProvinceCapital(String capitalWoeid) {
+        List<WeatherData> weatherData = metaWeatherApiService.getWeatherData(capitalWoeid);
+
+        String currentDay = currentDateUtils.getCurrentDay();
+
+        return weatherData.stream().filter(dataSet -> dataSet.getApplicableDate().equals(currentDay)).findAny();
+    }
+
+    public ProvinceCapitalWeatherData getProvinceCapitalWeatherData(String capital, WeatherData data) {
+        return new ProvinceCapitalWeatherData(
+                capital,
+                WeatherCategories.getWeatherCategory(data.getWeatherStateAbbreviation().toUpperCase()),
+                (int)Math.round(data.getMinTemperature()),
+                (int)Math.round(data.getMaxTemperature()),
+                (int)Math.round(data.getCurrentTemperature())
+        );
     }
 }

--- a/backend/src/main/java/de/neuefische/teddyscoronadiaries/utils/CurrentDateUtils.java
+++ b/backend/src/main/java/de/neuefische/teddyscoronadiaries/utils/CurrentDateUtils.java
@@ -1,0 +1,16 @@
+package de.neuefische.teddyscoronadiaries.utils;
+
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+
+@Repository
+public class CurrentDateUtils {
+
+    public String getCurrentDay(){
+        return Instant.now()
+                .toString()
+                .split("T")[0];
+    }
+
+}

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/WeatherControllerTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/WeatherControllerTest.java
@@ -82,7 +82,7 @@ class WeatherControllerTest {
     @DisplayName("Get province capital weather data should throw error for unknown province")
     public void getProvinceCapitalWeatherDataShouldThrowErrorForUnknownProvince(){
         // Given
-        String province = "michGibtsNicht";
+        String province = "Bielefeld";
 
         // When
         ResponseEntity<Void> response = testRestTemplate.getForEntity(getUrl() + "/" + province, Void.class);

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/WeatherControllerTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/controller/WeatherControllerTest.java
@@ -1,0 +1,151 @@
+package de.neuefische.teddyscoronadiaries.controller;
+
+import de.neuefische.teddyscoronadiaries.db.ProvinceMongoDb;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherData;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherDataWrapper;
+import de.neuefische.teddyscoronadiaries.model.province.ProvinceData;
+import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherData;
+import de.neuefische.teddyscoronadiaries.utils.CurrentDateUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class WeatherControllerTest {
+
+    @LocalServerPort
+    int serverPort;
+
+    private String getUrl() {
+        return "http://localhost:" + serverPort + "/api/weather";
+    }
+
+    @MockBean
+    private CurrentDateUtils currentDateUtils;
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private ProvinceMongoDb provinceMongoDb;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @BeforeEach
+    public void setup() {
+        provinceMongoDb.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Get province capital weather data should return weather data")
+    public void getProvinceCapitalWeatherDataShouldReturnWeatherData() {
+        // Given
+        String province = "Hamburg";
+        provinceMongoDb.save(new ProvinceData("Hamburg", "Hamburg", "656958"));
+        when(currentDateUtils.getCurrentDay()).thenReturn("2021-03-21");
+        when(restTemplate.getForEntity("https://www.metaweather.com/api/location/656958", WeatherDataWrapper.class))
+                .thenReturn(ResponseEntity.ok(new WeatherDataWrapper(getWeatherDataList())));
+
+        // When
+        ResponseEntity<ProvinceCapitalWeatherData> response = testRestTemplate.getForEntity(getUrl() + "/" + province, ProvinceCapitalWeatherData.class);
+
+        // Then
+        assertThat(response.getStatusCode(), is(HttpStatus.OK));
+        assertThat(response.getBody(), is(new ProvinceCapitalWeatherData(
+                "Hamburg",
+                "Sonnig",
+                6,
+                20,
+                20,
+                "https://www.metaweather.com/static/img/weather/c.svg"
+        )));
+    }
+
+    @Test
+    @DisplayName("Get province capital weather data should throw error for unknown province")
+    public void getProvinceCapitalWeatherDataShouldThrowErrorForUnknownProvince(){
+        // Given
+        String province = "michGibtsNicht";
+
+        // When
+        ResponseEntity<Void> response = testRestTemplate.getForEntity(getUrl() + "/" + province, Void.class);
+
+        // Then
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+
+    }
+
+    @Test
+    @DisplayName("Get province capital weather data should throw error when API unavailable")
+    public void getProvinceCapitalWeatherdataShouldThrowErrorWhenApiUnavailable() {
+        // Given
+        String province = "Hamburg";
+        provinceMongoDb.save(new ProvinceData("Hamburg", "Hamburg", "656958"));
+        when(currentDateUtils.getCurrentDay()).thenReturn("2021-03-21");
+        when(restTemplate.getForEntity("https://www.metaweather.com/api/location/656958", WeatherDataWrapper.class))
+                .thenThrow(new RestClientException("API not available"));
+
+        // When
+        ResponseEntity<Void> response = testRestTemplate.getForEntity(getUrl() + "/" + province, Void.class);
+
+        // Then
+        assertThat(response.getStatusCode(), is(HttpStatus.NOT_FOUND));
+    }
+
+
+    private List<WeatherData> getWeatherDataList() {
+        return List.of(
+                WeatherData.builder()
+                        .id("123")
+                        .weatherStateName("Clear")
+                        .weatherStateAbbreviation("c")
+                        .applicableDate("2021-03-21")
+                        .minTemperature(5.9865)
+                        .maxTemperature(20.345)
+                        .currentTemperature(20.240000000000002)
+                        .windSpeed(8.930032549754765)
+                        .humidity(50)
+                        .build(),
+                WeatherData.builder()
+                        .id("345")
+                        .weatherStateName("Light Cloud")
+                        .weatherStateAbbreviation("c")
+                        .applicableDate("2021-03-22")
+                        .minTemperature(6.485)
+                        .maxTemperature(16.725)
+                        .currentTemperature(15.93)
+                        .windSpeed(2.884157589803547)
+                        .humidity(70)
+                        .build(),
+                WeatherData.builder()
+                        .id("567")
+                        .weatherStateName("Heavy Cloud")
+                        .weatherStateAbbreviation("hc")
+                        .applicableDate("2021-03-23")
+                        .minTemperature(3.875)
+                        .maxTemperature(13.86)
+                        .currentTemperature(12.065000000000001)
+                        .windSpeed(4.708858778127734)
+                        .humidity(71)
+                        .build()
+        );
+    }
+
+}

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/metaweatherapi/service/MetaWeatherApiServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/metaweatherapi/service/MetaWeatherApiServiceTest.java
@@ -1,0 +1,99 @@
+package de.neuefische.teddyscoronadiaries.metaweatherapi.service;
+
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherData;
+import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherDataWrapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MetaWeatherApiServiceTest {
+
+    private final RestTemplate restTemplate = mock(RestTemplate.class);
+    private static final String baseUrl = "https://www.metaweather.com";
+    private final MetaWeatherApiService metaWeatherApiService = new MetaWeatherApiService(restTemplate);
+
+    @Test
+    @DisplayName("Get weather data returns list of consilidated weather data")
+    public void getWeatherDataReturnsListOfWeatherData() {
+        // Given
+        String woeid = "656958";
+
+        when(restTemplate.getForEntity(baseUrl + "/api/location/" + woeid, WeatherDataWrapper.class))
+                .thenReturn(ResponseEntity.ok(new WeatherDataWrapper(getWeatherDataList())));
+
+        // When
+        List<WeatherData> weatherData = metaWeatherApiService.getWeatherData(woeid);
+
+        // Then
+        assertThat(weatherData, is(getWeatherDataList()));
+
+    }
+
+    @Test
+    @DisplayName("Get weather data returns empty list when API unavailable")
+    public void getWeatherDataReturnsEmptyList() {
+        // Given
+        String woeid = "656958";
+
+        when(restTemplate.getForEntity(baseUrl + "/api/location/" + woeid, WeatherDataWrapper.class))
+                .thenThrow(new RestClientException("Service not available"));
+
+        // When
+        List<WeatherData> weatherData = metaWeatherApiService.getWeatherData(woeid);
+
+        // Then
+        assertThat(weatherData, is(List.of()));
+
+    }
+
+
+    private List<WeatherData> getWeatherDataList() {
+        return List.of(
+                WeatherData.builder()
+                        .id("123")
+                        .weatherStateName("Clear")
+                        .weatherStateAbbreviation("c")
+                        .applicableDate("2021-03-21")
+                        .minTemperature(5.9865)
+                        .maxTemperature(20.345)
+                        .currentTemperature(20.240000000000002)
+                        .windSpeed(8.930032549754765)
+                        .humidity(50)
+                        .build(),
+                WeatherData.builder()
+                        .id("345")
+                        .weatherStateName("Light Cloud")
+                        .weatherStateAbbreviation("c")
+                        .applicableDate("2021-03-22")
+                        .minTemperature(6.485)
+                        .maxTemperature(16.725)
+                        .currentTemperature(15.93)
+                        .windSpeed(2.884157589803547)
+                        .humidity(70)
+                        .build(),
+                WeatherData.builder()
+                        .id("567")
+                        .weatherStateName("Heavy Cloud")
+                        .weatherStateAbbreviation("hc")
+                        .applicableDate("2021-03-23")
+                        .minTemperature(3.875)
+                        .maxTemperature(13.86)
+                        .currentTemperature(12.065000000000001)
+                        .windSpeed(4.708858778127734)
+                        .humidity(71)
+                        .build()
+        );
+    }
+
+}

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
@@ -1,4 +1,42 @@
+package de.neuefische.teddyscoronadiaries.model.weather;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
+
 class WeatherCategoriesTest {
-  
+
+    @ParameterizedTest(name = "Get weather category should return correct value")
+    @MethodSource("getWeatherCategoryValues")
+    public void getWeatherCategoryShouldReturnCorrectValue(String apiCategory, String result){
+        // When
+        String weatherCategory = WeatherCategories.getWeatherCategory(apiCategory);
+
+        // Then
+        assertThat(weatherCategory, is(result));
+
+    }
+
+    private static Stream<Arguments> getWeatherCategoryValues() {
+        return Stream.of(
+                Arguments.of("SN", "Schnee"),
+                Arguments.of("SL", "Schneeregen"),
+                Arguments.of("H", "Hagel"),
+                Arguments.of("T", "Gewitter"),
+                Arguments.of("HR", "Starkregen"),
+                Arguments.of("LR", "Leichter Regen"),
+                Arguments.of("S", "Regen"),
+                Arguments.of("HC", "Bewölkt"),
+                Arguments.of("LC", "Leicht bewölkt"),
+                Arguments.of("C", "Sonnig")
+        );
+    }
+
 }

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
@@ -1,6 +1,5 @@
 package de.neuefische.teddyscoronadiaries.model.weather;
 
-import org.hamcrest.Matchers;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -17,7 +16,7 @@ class WeatherCategoriesTest {
     @MethodSource("getWeatherCategoryValues")
     public void getWeatherCategoryShouldReturnCorrectValue(String apiCategory, String result){
         // When
-        String weatherCategory = WeatherCategories.getWeatherCategory(apiCategory);
+        String weatherCategory = WeatherCategories.getWeatherCategory(apiCategory).get();
 
         // Then
         assertThat(weatherCategory, is(result));

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/model/weather/WeatherCategoriesTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class WeatherCategoriesTest {
+  
+}

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
@@ -5,7 +5,7 @@ import de.neuefische.teddyscoronadiaries.metaweatherapi.model.WeatherData;
 import de.neuefische.teddyscoronadiaries.metaweatherapi.service.MetaWeatherApiService;
 import de.neuefische.teddyscoronadiaries.model.province.ProvinceData;
 import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherData;
-import org.hamcrest.Matchers;
+import de.neuefische.teddyscoronadiaries.utils.CurrentDateUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +20,8 @@ class WeatherServiceTest {
 
     private final MetaWeatherApiService metaWeatherApiService = mock(MetaWeatherApiService.class);
     private final ProvinceMongoDb provinceMongoDb = mock(ProvinceMongoDb.class);
-    private final WeatherService weatherService = new WeatherService(metaWeatherApiService, provinceMongoDb);
+    private final CurrentDateUtils currentDateUtils = mock(CurrentDateUtils.class);
+    private final WeatherService weatherService = new WeatherService(metaWeatherApiService, provinceMongoDb, currentDateUtils);
 
     @Test
     @DisplayName("get province capital weather data should return weather data")
@@ -29,6 +30,7 @@ class WeatherServiceTest {
         String province = "Hamburg";
         String capitalWoeid = "656958";
 
+        when(currentDateUtils.getCurrentDay()).thenReturn("2021-03-21");
         when(provinceMongoDb.findById(province)).thenReturn(java.util.Optional.of(new ProvinceData("Hamburg", "Hamburg", "656958")));
         when(metaWeatherApiService.getWeatherData(capitalWoeid)).thenReturn(getWeatherDataList());
 

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
@@ -56,7 +56,7 @@ class WeatherServiceTest {
     @DisplayName("Get province capital weather data should throw error when province is unknown")
     public void getProvinceCapitalWeatherdataShouldThrowErrorWhenProvinceIsUnknown() {
         // Given
-        String province = "michGibtsNicht";
+        String province = "Bielefeld";
         when(provinceMongoDb.findById(province)).thenReturn(Optional.empty());
 
         // Then
@@ -112,7 +112,7 @@ class WeatherServiceTest {
 
     @Test
     @DisplayName("Get province capital weather data from weather data should return correct object")
-    public void getProvinceCpitalWeatherDataFromWeatherDataTest() {
+    public void getProvinceCapitalWeatherDataFromWeatherDataTest() {
         // Given
         String capital = "Hamburg";
         WeatherData weatherData = WeatherData.builder()

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
@@ -8,11 +8,14 @@ import de.neuefische.teddyscoronadiaries.model.weather.ProvinceCapitalWeatherDat
 import de.neuefische.teddyscoronadiaries.utils.CurrentDateUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -48,6 +51,97 @@ class WeatherServiceTest {
         )));
 
     }
+
+    @Test
+    @DisplayName("Get province capital weather data should throw error when province is unknown")
+    public void getProvinceCapitalWeatherdataShouldThrowErrorWhenProvinceIsUnknown() {
+        // Given
+        String province = "michGibtsNicht";
+        when(provinceMongoDb.findById(province)).thenReturn(Optional.empty());
+
+        // Then
+        assertThrows(ResponseStatusException.class, () -> {
+            weatherService.getProvinceCapitalWeatherData(province);
+        });
+
+    }
+
+    @Test
+    @DisplayName("Get province capital weather data should throw error when API is unavailable")
+    public void getProvinceCapitalWeatherDataShouldThrowErrorWhenApiIsUnavailable() {
+        // Given
+        String province = "Hamburg";
+        String capitalWoeid = "656958";
+
+        when(currentDateUtils.getCurrentDay()).thenReturn("2021-03-21");
+        when(provinceMongoDb.findById(province)).thenReturn(java.util.Optional.of(new ProvinceData("Hamburg", "Hamburg", "656958")));
+        when(metaWeatherApiService.getWeatherData(capitalWoeid)).thenReturn(List.of());
+
+        // Then
+        assertThrows(ResponseStatusException.class, () -> {
+            weatherService.getProvinceCapitalWeatherData(province);
+        });
+
+    }
+
+    @Test
+    @DisplayName("Get weather data for province capital should return correct weather data set")
+    public void getWeatherdataForProvinceCapitalShouldReturnWeatherDataSet() {
+        // Given
+        String capitalWoeid = "656958";
+        when(currentDateUtils.getCurrentDay()).thenReturn("2021-03-21");
+        when(metaWeatherApiService.getWeatherData(capitalWoeid)).thenReturn(getWeatherDataList());
+
+        // When
+        Optional<WeatherData> result = weatherService.getWeatherDataForProvinceCapital(capitalWoeid);
+
+        // Then
+        assertThat(result.get(), is(WeatherData.builder()
+                .id("123")
+                .weatherStateName("Clear")
+                .weatherStateAbbreviation("c")
+                .applicableDate("2021-03-21")
+                .minTemperature(5.9865)
+                .maxTemperature(20.345)
+                .currentTemperature(20.240000000000002)
+                .windSpeed(8.930032549754765)
+                .humidity(50)
+                .build()));
+
+    }
+
+    @Test
+    @DisplayName("Get province capital weather data from weather data should return correct object")
+    public void getProvinceCpitalWeatherDataFromWeatherDataTest() {
+        // Given
+        String capital = "Hamburg";
+        WeatherData weatherData = WeatherData.builder()
+                .id("123")
+                .weatherStateName("Clear")
+                .weatherStateAbbreviation("c")
+                .applicableDate("2021-03-21")
+                .minTemperature(5.9865)
+                .maxTemperature(20.345)
+                .currentTemperature(20.240000000000002)
+                .windSpeed(8.930032549754765)
+                .humidity(50)
+                .build();
+
+        // When
+        ProvinceCapitalWeatherData result = weatherService.getProvinceCapitalWeatherDataFromWeatherData(capital, weatherData);
+
+        // Then
+        assertThat(result, is(new ProvinceCapitalWeatherData(
+                "Hamburg",
+                "Sonnig",
+                6,
+                20,
+                20,
+                "https://www.metaweather.com/static/img/weather/c.svg"
+        )));
+
+    }
+
 
     private List<WeatherData> getWeatherDataList() {
         return List.of(

--- a/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
+++ b/backend/src/test/java/de/neuefische/teddyscoronadiaries/service/WeatherServiceTest.java
@@ -43,7 +43,8 @@ class WeatherServiceTest {
                 "Sonnig",
                 6,
                 20,
-                20
+                20,
+                "https://www.metaweather.com/static/img/weather/c.svg"
         )));
 
     }


### PR DESCRIPTION
- add metaweather API service as well as DTO classes 
- add weather service to translate metaweather API response into internal model
- add weather controller to retrieve weather data for capital of provided province
- add additional mongo DB collection for province data with woeid (where on earth ID) commonly used in weather APIs 